### PR TITLE
Fixed issue with invisible fields in element modals

### DIFF
--- a/pimpmymatrix/resources/css/pimpmymatrix.css
+++ b/pimpmymatrix/resources/css/pimpmymatrix.css
@@ -72,6 +72,7 @@ body.rtl .buttons-pimped > .btn, body.rtl .buttons-pimped > .btngroup { margin: 
 }
 
 /* don’t break blocks that don’t need pimping */
+.elementeditor .matrix-field .matrixblock .fields,
 .matrix-field .matrixblock.matrixblock-not-pimped .fields {
   -webkit-opacity: 1;
   -moz-opacity: 1;

--- a/pimpmymatrix/resources/css/pimpmymatrix.css
+++ b/pimpmymatrix/resources/css/pimpmymatrix.css
@@ -73,6 +73,7 @@ body.rtl .buttons-pimped > .btn, body.rtl .buttons-pimped > .btngroup { margin: 
 
 /* don’t break blocks that don’t need pimping */
 .elementeditor .matrix-field .matrixblock .fields,
+.superTableContainer .matrix-field .matrixblock .fields,
 .matrix-field .matrixblock.matrixblock-not-pimped .fields {
   -webkit-opacity: 1;
   -moz-opacity: 1;


### PR DESCRIPTION
Matrix fields aren’t getting “pimped” in element modals, but their fields were still getting hidden. Made a change to show fields if they’re within one of these modal windows.

Not sure if you're taking pull requests but thought I'd open one anyway!