### PR TITLE
Fix issue with long PMM list being inaccessible on Live Preview

### DIFF
--- a/pimpmymatrix/resources/css/pimpmymatrix.css
+++ b/pimpmymatrix/resources/css/pimpmymatrix.css
@@ -132,3 +132,10 @@ body.rtl .buttons-pimped > .btn, body.rtl .buttons-pimped > .btngroup { margin: 
 .pimpmymatrix-secondary-menu {
   padding-top: 10px;
 }
+
+/* Keep long secondary menu from going offscreen on Live Preview where scrolling is not possible */
+html.noscroll .pimpmymatrix-secondary-menu {
+  max-height: 50%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}


### PR DESCRIPTION
If Live Preview and/or a page in the CP where the html tag has the noscroll class is being used, long PMM lists scroll off screen and are not accessible at all. Recommending that PMM makes its list scrollable with a maximum height on non-scrolling CP sections.